### PR TITLE
修改 302 重定向状态码为 307，解决 POST 请求错误的被重定向为 GET 请求的问题

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -142,7 +142,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 			io.WriteString(w, "Missing Host header.")
 		} else if c.HttpOnHttpsPortErrorHandler == nil {
 			// Redirect
-			RedirectToHttps(w, r, 302)
+			RedirectToHttps(w, r, 307)
 		} else {
 			// Handler
 			w.Resp.Request = r


### PR DESCRIPTION
我在使用中发现 302 只能重定向 GET 请求，如果是 POST 请求，则会被错误的重定向到 GET 请求，通过尝试 改为 307 重定向就可以解决此问题。

307 和302 的唯一区别：301或302重定向时，可能会改 Post为 Get ,而 307 时则不会

可参考 https://segmentfault.com/q/1010000043433837
