### PR TITLE
Support any future uppercase HTTP methods, including QUERY.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you need to customize the redirect handler, see [HlfhrHandler Example](#hlfhr
 flowchart TD
 	Read("Hijacking net.Conn.Read")
 
-	IsLooksLikeHTTP("First byte looks like HTTP ?")
+	IsUpperCase("First byte is upper case ?")
 
 	CancelHijacking(["✅ Cancel hijacking..."])
 
@@ -69,9 +69,9 @@ flowchart TD
 
 	Close(["❌ Close."])
 
-    Read --> IsLooksLikeHTTP
-    IsLooksLikeHTTP -- "🔐false" --> CancelHijacking
-    IsLooksLikeHTTP -- "📄true" --> ReadRequest --> IsHandlerExist
+    Read --> IsUpperCase
+    IsUpperCase -- "🔐false" --> CancelHijacking
+    IsUpperCase -- "📄true" --> ReadRequest --> IsHandlerExist
 	IsHandlerExist -- "✖false" --> Redirect --> Close
 	IsHandlerExist -- "✅true" --> Handler --> Close
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you need to customize the redirect handler, see [HlfhrHandler Example](#hlfhr
 flowchart TD
 	Read("Hijacking net.Conn.Read")
 
-	IsUpperCase("First byte is upper case ?")
+	IsUpperCase("Is the first byte uppercase?")
 
 	CancelHijacking(["✅ Cancel hijacking..."])
 

--- a/src_conn.go
+++ b/src_conn.go
@@ -23,7 +23,8 @@ func (c *Conn) Read(b []byte) (int, error) {
 		return n, err
 	}
 
-	// TLS record types (20-23) < 'A': skip TLS, catch HTTP (A-Z) then abort.
+	// TLS record types (20-23) < 'A':
+	// skip TLS, serve HTTP (A-Z) and abort (panic).
 	if b[0] >= 'A' && b[0] <= 'Z' {
 		// HTTP
 		// len(b) == 576

--- a/src_conn.go
+++ b/src_conn.go
@@ -24,7 +24,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 	}
 
 	// TLS record types (20-23) < 'A':
-	// skip TLS, serve HTTP (A-Z) and abort (panic).
+	// skip TLS, serve HTTP (A-Z) and abort via http.ErrAbortHandler.
 	if b[0] >= 'A' && b[0] <= 'Z' {
 		// HTTP
 		// len(b) == 576

--- a/src_conn.go
+++ b/src_conn.go
@@ -23,6 +23,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 		return n, err
 	}
 
+	// TLS rec types (20-23) < 'A': skip TLS, catch HTTP (A-Z) and abort.
 	if b[0] >= 'A' && b[0] <= 'Z' {
 		// HTTP
 		// len(b) == 576

--- a/src_conn.go
+++ b/src_conn.go
@@ -23,7 +23,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 		return n, err
 	}
 
-	// TLS rec types (20-23) < 'A': skip TLS, catch HTTP (A-Z) and abort.
+	// TLS record types (20-23) < 'A': skip TLS, catch HTTP (A-Z) then abort.
 	if b[0] >= 'A' && b[0] <= 'Z' {
 		// HTTP
 		// len(b) == 576

--- a/src_conn.go
+++ b/src_conn.go
@@ -23,21 +23,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 		return n, err
 	}
 
-	// Does the first byte look like HTTP?
-	switch b[0] {
-	case 22, // recordTypeHandshake
-		20, // recordTypeChangeCipherSpec
-		21, // recordTypeAlert
-		23: // recordTypeApplicationData
-		// TLS
-
-	case 'G', // GET
-		'H', // HEAD
-		'P', // POST PUT PATCH
-		'D', // DELETE
-		'C', // CONNECT
-		'O', // OPTIONS
-		'T': // TRACE
+	if b[0] >= 'A' && b[0] <= 'Z' {
 		// HTTP
 		// len(b) == 576
 		c.HlfhrServe(b, n)

--- a/testdata/main_test.go
+++ b/testdata/main_test.go
@@ -97,6 +97,7 @@ func request(serverAddr string) {
 		"OPTIONS",
 		"TRACE",
 		"PATCH",
+		"QUERY",
 	} {
 		println(method)
 


### PR DESCRIPTION
The HTTP QUERY Method:  
https://datatracker.ietf.org/doc/rfc10008/